### PR TITLE
Add markdown support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/stewartad/powerlinx
 
 go 1.18
+
+require github.com/yuin/goldmark v1.4.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/yuin/goldmark v1.4.12 h1:6hffw6vALvEDqJ19dOJvJKOoAOKe4NDaTqvd2sktGN0=
+github.com/yuin/goldmark v1.4.12/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/powerlinx.go
+++ b/powerlinx.go
@@ -26,6 +26,7 @@ var markdown = goldmark.New(
 	),
 	goldmark.WithRendererOptions(
 		html.WithHardWraps(),
+		html.WithUnsafe(),
 	),
 )
 


### PR DESCRIPTION
- Add Goldmark dependency for markdown parsing
- Pages can have either .md or .html extensions
- HTML within .md files is allowed and parsed
- Within the site's PageMap, filepaths now include the first /